### PR TITLE
Make update to spead 2.0.0 actually work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cover
 .coverage
 .mypy_cache
 *.egg-info
+pip-wheel-metadata

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN make -j4
 RUN make DESTDIR=/libhdf5-install install
 RUN make install
 RUN ldconfig
-RUN echo -e "Name: HDF5\nDescription: Hierarchical Data Format 5 (HDF5)\nVersion: $HDF5_VERSION\nRequires:\nCflags: -I/usr/local/include\nLibs: -L/usr/local/lib -lhdf5" \
+RUN echo "Name: HDF5\nDescription: Hierarchical Data Format 5 (HDF5)\nVersion: $HDF5_VERSION\nRequires:\nCflags: -I/usr/local/include\nLibs: -L/usr/local/lib -lhdf5" \
         > /usr/lib/x86_64-linux-gnu/pkgconfig/hdf5.pc
 USER kat
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "katversion==0.9", "jinja2==2.10.1", "pycparser==2.19", "pkgconfig==1.5.1"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,10 @@ decorator                 # via aiokatcp
 fakeredis                 # via katsdptelstate
 h5py
 ipaddress                 # via katsdptelstate
-katversion
 hiredis                   # via katsdptelstate
 msgpack                   # via katsdptelstate
 netifaces                 # via katsdptelstate
 numpy
-pkgconfig==1.2.2
 pygelf                    # via katsdpservices
 redis                     # via katsdptelstate
 six                       # via h5py, spead2

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
     hdf5 = collections.defaultdict(list)
 
 
-tests_require = ['nose', 'spead2>=1.11.1', 'asynctest']
+tests_require = ['nose', 'spead2>=2.0.0', 'asynctest']
 
 
 class get_include:

--- a/setup.py
+++ b/setup.py
@@ -56,14 +56,18 @@ class BuildExt(build_ext):
         build_ext.run(self)
 
 
+sources = (glob.glob('spead2/src/common_*.cpp') +
+           glob.glob('spead2/src/recv_*.cpp') +
+           glob.glob('spead2/src/send_*.cpp') +
+           glob.glob('spead2/src/py_common.cpp') +
+           glob.glob('katsdpbfingest/*.cpp'))
+# Generated file might or might not be matched by the file now
+if 'spead2/src/common_ibv_loader.cpp' not in sources:
+    sources.append('spead2/src/common_ibv_loader.cpp')
 extensions = [
     Extension(
         '_bf_ingest',
-        sources=(glob.glob('spead2/src/common_*.cpp') +
-                 glob.glob('spead2/src/recv_*.cpp') +
-                 glob.glob('spead2/src/send_*.cpp') +
-                 glob.glob('spead2/src/py_common.cpp') +
-                 glob.glob('katsdpbfingest/*.cpp')),
+        sources=sources,
         depends=(glob.glob('spead2/include/spead2/*.h') +
                  glob.glob('spead2/3rdparty/pybind11/include/pybind11/*.h') +
                  glob.glob('spead2/3rdparty/pybind11/include/pybind11/detail/*.h') +

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ class get_include:
 class BuildExt(build_ext):
     def run(self):
         self.mkpath(self.build_temp)
-        subprocess.check_call(['./bootstrap.sh', '--no-python'], cwd='spead2')
+        subprocess.check_call(['./bootstrap.sh'], cwd='spead2')
         subprocess.check_call(os.path.abspath('spead2/configure'), cwd=self.build_temp)
         # Ugly hack to add libraries conditional on configure result
         have_ibv = False

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,6 @@ setup(
     ext_modules=extensions,
     cmdclass={'build_ext': BuildExt},
     scripts=["scripts/bf_ingest.py"],
-    setup_requires=['katversion', 'pkgconfig'],
     install_requires=[
         'h5py',
         'numpy',


### PR DESCRIPTION
- Added a pyproject.toml so that jinja2 and pycparser will be installed
  at build time. This also allowed katversion and pkgconfig to be removed
  from runtime.
- Fix the creation of hdf5.pc, which wasn't working properly with the
  latest version of the Python pkgconfig package.