### PR TITLE
Unpin katversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "katversion==1.0", "jinja2==2.11.2", "pycparser==2.20", "pkgconfig==1.5.1", "pybind11==2.7.1"]
+requires = ["setuptools", "wheel", "katversion", "jinja2==2.11.2", "pycparser==2.20", "pkgconfig==1.5.1", "pybind11==2.7.1"]


### PR DESCRIPTION
All the other SDP packages use katversion unpinned, and since setuptools
was unpinned, pinning katversion would have prevented picking up the
bugfix in katversion 1.2 needed to work with the latest setuptools.