### PR TITLE
SPR1-2999: Set cap_net_raw on bfingest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,5 +57,10 @@ USER kat
 COPY --from=build --chown=kat:kat /home/kat/ve3 /home/kat/ve3
 ENV PATH="$PATH_PYTHON3" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON3"
 
+# Allow raw packets (for ibverbs raw QPs)
+USER root
+RUN setcap cap_net_raw+p /usr/local/bin/capambel
+USER kat
+
 EXPOSE 2050
 EXPOSE 7148/udp


### PR DESCRIPTION
This allows the product controller to run the script as `capambel -c cap_net_raw+p -- ...` to use ibverbs.

The capambel tool is used to pass capabilities to the bf_ingest script but it needs those capabilities itself. Since Docker 20.10.14 the capabilities are not inherited anymore so set it explicitly.

This is a repeat of ska-sa/katsdpingest#368.