### PR TITLE
SPR1-3001 make bfingest build again

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.9.2
   hooks:
     - id: flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "katversion", "jinja2==2.11.2", "pycparser==2.20", "pkgconfig==1.5.1", "pybind11==2.7.1"]
+requires = ["setuptools", "wheel", "katversion", "jinja2==2.11.2", "markupsafe==2.0.1", "pycparser==2.20", "pkgconfig==1.5.1", "pybind11==2.7.1"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
--c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
+-d https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
 aiokatcp
-h5py
+h5py==3.8.0
 numpy
 spead2
+
 katsdpservices[argparse,aiomonitor] @ git+https://github.com/ska-sa/katsdpservices
 katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate


### PR DESCRIPTION
This will:
+ pin a version of markupsafe that has `soft_unicode`
+ update broken flake8 mirror 
+ make base-requirements.txt into defaults rather than constraints in order to pin h5py to 3.8.0