### PR TITLE
Dont write telstate by default.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ USER root
 WORKDIR /tmp
 ENV HDF5_VERSION=1.10.3
 ARG KATSDPDOCKERBASE_MIRROR=http://sdp-services.kat.ac.za/mirror
-RUN mirror_wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-$HDF5_VERSION/src/hdf5-$HDF5_VERSION.tar.bz2 -O hdf5-$HDF5_VERSION.tar.bz2
+RUN mirror_wget https://s3.amazonaws.com/hdf-wordpress-1/wp-content/uploads/manual/HDF5/hdf5-$HDF5_VERSION.tar.bz2 -O hdf5-$HDF5_VERSION.tar.bz2
 RUN tar -jxf hdf5-$HDF5_VERSION.tar.bz2
 WORKDIR /tmp/hdf5-$HDF5_VERSION
 RUN ./configure --prefix=/usr/local --enable-build-mode=production --enable-threadsafe \


### PR DESCRIPTION
See https://skaafrica.atlassian.net/browse/OPS-6008. It was identified that during long VLBI runs, a bfingest process was being killed with an OOM error because it exceeded its cgroup memory allocation, causing downstream errors. This was due to it writing telstate data that was large (many bpcal solutions). Discussion revealed that it would be preferable to not write telstate to .hdf5 files at all for VLBI. This PR implements that preference. The option to write telstate is left as a command-line option.

There are other solutions. It was suggested to use a katspcontroller code path for telstate-writing processes to assign more memory to bfingest. Investigating this is captured in https://skaafrica.atlassian.net/browse/SPP1-192